### PR TITLE
set updated theme version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 # Defining the exact version will make sure things don't break
-sphinx<6
+#sphinx<6
+sphinx-rtd-theme>1.2


### PR DESCRIPTION
Sometime the week of October 2, there was an update somewhere with ReadTheDocs that caused new builds to fail unless it had a very specific clause in the requirements.  

This commit sets up that line and makes the repo build again.