### PR TITLE
clean software index

### DIFF
--- a/docs/source/software/index.rst
+++ b/docs/source/software/index.rst
@@ -133,4 +133,3 @@ will review requests for broad use and installation effort.
    :hidden:
 
    R/index
-   

--- a/docs/source/software/index.rst
+++ b/docs/source/software/index.rst
@@ -123,15 +123,13 @@ will review requests for broad use and installation effort.
 
 Python
 -------------------------
-
+   python/index
+   python_env/index
 
 
 R
 -------------------------
-.. toctree::
-   :maxdepth: 2
-   
-   python/index
-   python_env/index
    R/index
    
+.. toctree::
+   :maxdepth: 2

--- a/docs/source/software/index.rst
+++ b/docs/source/software/index.rst
@@ -121,11 +121,17 @@ documented <here>. Delta support staff are available to provide limited
 assistance. For general installation requests the Delta project office
 will review requests for broad use and installation effort.
 
+Python
+--------
+
 .. toctree::
    :caption: Python
 
    python/index
    python_env/index
+
+R
+---
 
 .. toctree::
    :caption: R

--- a/docs/source/software/index.rst
+++ b/docs/source/software/index.rst
@@ -138,5 +138,6 @@ R
 .. toctree::
    :caption: R
    :hidden:
+
    R/index
    

--- a/docs/source/software/index.rst
+++ b/docs/source/software/index.rst
@@ -121,19 +121,12 @@ documented <here>. Delta support staff are available to provide limited
 assistance. For general installation requests the Delta project office
 will review requests for broad use and installation effort.
 
-Python
--------------------------
-
 .. toctree::
    :caption: Python
    :hidden:
 
    python/index
    python_env/index
-
-
-R
--------------------------
 
 .. toctree::
    :caption: R

--- a/docs/source/software/index.rst
+++ b/docs/source/software/index.rst
@@ -123,13 +123,11 @@ will review requests for broad use and installation effort.
 
 .. toctree::
    :caption: Python
-   :hidden:
 
    python/index
    python_env/index
 
 .. toctree::
    :caption: R
-   :hidden:
 
    R/index

--- a/docs/source/software/index.rst
+++ b/docs/source/software/index.rst
@@ -123,6 +123,7 @@ will review requests for broad use and installation effort.
 
 Python
 -------------------------
+
 .. toctree::
    :caption: Python
    :hidden:
@@ -133,6 +134,7 @@ Python
 
 R
 -------------------------
+
 .. toctree::
    :caption: R
    :hidden:

--- a/docs/source/software/index.rst
+++ b/docs/source/software/index.rst
@@ -123,13 +123,18 @@ will review requests for broad use and installation effort.
 
 Python
 -------------------------
+.. toctree::
+   :caption: Python
+   :hidden:
+
    python/index
    python_env/index
 
 
 R
 -------------------------
+.. toctree::
+   :caption: R
+   :hidden:
    R/index
    
-.. toctree::
-   :maxdepth: 2


### PR DESCRIPTION
Attempting to change the indexing so that python and R show up in the proper place in the page outline and in the TOC.